### PR TITLE
PR:Add PaymentMethod-PurchaseOrder relationship and ReportCustomer

### DIFF
--- a/src/AppForSEII2526.API/Data/ApplicationDbContext.cs
+++ b/src/AppForSEII2526.API/Data/ApplicationDbContext.cs
@@ -29,12 +29,23 @@ public class ApplicationDbContext(DbContextOptions<ApplicationDbContext> options
     protected override void OnModelCreating(ModelBuilder builder)
     {
         base.OnModelCreating(builder);
-        
-    builder.Entity<ReturnProduct>()
-        .HasOne(rp => rp.PurchaseProduct)
-        .WithOne(pp => pp.ReturnProduct)
-        .HasForeignKey<ReturnProduct>(rp => new { rp.ProductId, rp.PurchaseOrderId })
-        .OnDelete(DeleteBehavior.NoAction);
+
+
+        builder.Entity<ReturnProduct>()
+            .HasOne(rp => rp.PurchaseProduct)
+            .WithOne(pp => pp.ReturnProduct)
+            .HasForeignKey<ReturnProduct>(rp => new { rp.ProductId, rp.PurchaseOrderId })
+            .OnDelete(DeleteBehavior.NoAction);
+
+
+        builder.Entity<PurchaseOrder>()
+            .HasOne(po => po.PaymentMethod)
+            .WithMany(pm => pm.PurchaseOrders)       
+            .HasForeignKey(po => po.PaymentMethodId)
+            .OnDelete(DeleteBehavior.NoAction);      
     }
+
+
+
     public DbSet<ReportCustomer> ReportCustomers { get; set; }
 }

--- a/src/AppForSEII2526.API/Models/PaymentMethod.cs
+++ b/src/AppForSEII2526.API/Models/PaymentMethod.cs
@@ -4,5 +4,6 @@
     {
         public int Id { get; set; }
         public ApplicationUser User { get; set; }
+        public ICollection<PurchaseOrder> PurchaseOrders { get; set; } 
     }
 }

--- a/src/AppForSEII2526.API/Models/PurchaseOrder.cs
+++ b/src/AppForSEII2526.API/Models/PurchaseOrder.cs
@@ -29,11 +29,13 @@
         public decimal TotalPrice { get; set; }
 
         public List<PurchaseProduct> PurchaseProducts { get; set; }
-        public PaymentMethod? PaymentMethod { get; set; }
+        public PaymentMethod PaymentMethod { get; set; }
         public PurchaseState State { get; set; }
         public ApplicationUser Customer { get; set; }
 
         public PurchaseDelivery DriverAssigned { get; set; }
+        public int PaymentMethodId { get; set; }
+
 
     }
     public enum PurchaseState


### PR DESCRIPTION
Updated `ApplicationDbContext`:
- Added `DbSet<ReportCustomer>` for managing `ReportCustomers`.
- Reformatted `ReturnProduct` relationship for readability.
- Added a new one-to-many relationship between `PurchaseOrder` and `PaymentMethod` with `NoAction` delete behavior.

Updated `PaymentMethod`:
- Added `ICollection<PurchaseOrder>` to represent related `PurchaseOrders`.

Updated `PurchaseOrder`:
- Made `PaymentMethod` non-nullable and added `PaymentMethodId` as a foreign key.