### PR TITLE
PR: Task 105 Unit tests for SelectProductsForPurchasing

### DIFF
--- a/src/AppForSEII2526.API/DTOs/ProductDTOs/ProductForPurchaseDTO.cs
+++ b/src/AppForSEII2526.API/DTOs/ProductDTOs/ProductForPurchaseDTO.cs
@@ -36,5 +36,16 @@ namespace AppForSEII2526.API.DTOs.ProductDTOs
 
         // City from related PurchaseOrder (may be null if never purchased)
         public string? City { get; set; }
+
+        public override bool Equals(object? obj)
+        {
+            return obj is ProductForPurchaseDTO dTO &&
+                   ProductId == dTO.ProductId &&
+                   Name == dTO.Name &&
+                   Colour == dTO.Colour &&
+                   Brand == dTO.Brand &&
+                   Stock == dTO.Stock &&
+                   City == dTO.City;
+        }
     }
 }

--- a/src/AppForSEII2526.API/Models/Brand.cs
+++ b/src/AppForSEII2526.API/Models/Brand.cs
@@ -3,6 +3,17 @@
     [Index(nameof(Name), IsUnique = true)]
     public class Brand
     {
+        public Brand()
+        {
+        }
+
+        public Brand(int id, string location, string name)
+        {
+            Id = id;
+            Location = location;
+            Name = name;
+        }
+
         public int Id { get; set; }
 
         public string Location { get; set; }

--- a/src/AppForSEII2526.API/Models/Product.cs
+++ b/src/AppForSEII2526.API/Models/Product.cs
@@ -4,6 +4,21 @@
     [Index(nameof(Name), IsUnique = true)]
     public class Product
     {
+        public Product()
+        {
+        }
+
+        public Product(int productId, string name, string? colour, decimal price, int stock, bool isReturnable, Brand brand)
+        {
+            ProductId = productId;
+            Name = name;
+            Colour = colour;
+            Price = price;
+            Stock = stock;
+            IsReturnable = isReturnable;
+            Brand = brand;
+        }
+
         [Key]
         public int ProductId { get; set; }
 

--- a/test/AppForSEII2526.UT/AppForSEII2526SqliteUT.cs.cs
+++ b/test/AppForSEII2526.UT/AppForSEII2526SqliteUT.cs.cs
@@ -1,0 +1,37 @@
+﻿using System.Data.Common;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+
+namespace AppForSEII2526.UT
+{
+    public class AppForSEII2526SqliteUT
+    {
+        protected readonly DbConnection _connection;
+        protected readonly ApplicationDbContext _context;
+        protected readonly DbContextOptions<ApplicationDbContext> _contextOptions;
+
+        // Si en algún test quieres un contexto "fresco"
+        protected ApplicationDbContext CreateContext() => new(_contextOptions);
+
+        // Importante: cierra la conexión cuando termine el test
+        void Dispose() => _connection.Dispose();
+
+        public AppForSEII2526SqliteUT()
+        {
+            _connection = new SqliteConnection("Filename=:memory:");
+            _connection.Open();
+            _contextOptions = new DbContextOptionsBuilder<ApplicationDbContext>()
+                .UseSqlite(_connection)
+                .Options;
+
+            _context = new ApplicationDbContext(_contextOptions);
+
+            if (_context.Database.EnsureCreated())
+            {
+                using var cmd = _context.Database.GetDbConnection().CreateCommand();
+                cmd.CommandText = @"CREATE VIEW AllProducts AS SELECT Name FROM Products;";
+                cmd.ExecuteNonQuery();
+            }
+        }
+    }
+}

--- a/test/AppForSEII2526.UT/PurchasesController_test/GetProductsForPurchasing_test.cs
+++ b/test/AppForSEII2526.UT/PurchasesController_test/GetProductsForPurchasing_test.cs
@@ -1,0 +1,71 @@
+﻿using AppForSEII2526.UT; // tu base SQLite en memoria (equivalente a AppForMovies4SqliteUT)
+using AppForSEII2526.API.Controllers;
+using AppForSEII2526.API.DTOs.ProductDTOs;
+using AppForSEII2526.API.Models;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace AppForSEII2526.UT.ProductsController_test
+{
+    public class GetProductsForPurchasing_test : AppForSEII2526SqliteUT
+    {
+        public GetProductsForPurchasing_test()
+        {
+            var brands = new List<Brand>() {
+                new Brand { Id = 1, Name = "Zara",   Location = "Madrid"    },
+                new Brand { Id = 2, Name = "Uniqlo", Location = "Barcelona" }
+            };
+
+            var products = new List<Product>(){
+                new Product { ProductId = 1, Name = "Jacket", Colour = "Red",  Price = 20.0m, Stock = 4,  IsReturnable = true,  Brand = brands[0] },
+                new Product { ProductId = 2, Name = "Shirt",  Colour = "Blue", Price = 10.0m, Stock = 10, IsReturnable = false, Brand = brands[1] },
+
+                // this product has stock=0 so it shouldn't be returned when calling GetProductsForPurchasing
+                new Product { ProductId = 3, Name = "Hat",    Colour = "Red",  Price =  5.0m, Stock = 0,  IsReturnable = false, Brand = brands[1] },
+            };
+
+            _context.AddRange(brands);
+            _context.AddRange(products);
+            _context.SaveChanges();
+        }
+
+        public static IEnumerable<object[]> TestCasesFor_GetProductsForPurchasing_OK()
+        {
+            // ¡OJO! El endpoint ordena por Colour (OrderBy Colour).
+            // Colores: "Blue" < "Red" alfabéticamente, por eso "Shirt" va antes que "Jacket".
+            var productDTOs = new List<ProductForPurchaseDTO>() {
+                new ProductForPurchaseDTO(2, "Shirt",  "Blue", "Uniqlo", 10, null),
+                new ProductForPurchaseDTO(1, "Jacket", "Red",  "Zara",    4, null),
+            };
+
+            var all = new List<ProductForPurchaseDTO>() { productDTOs[0], productDTOs[1] }; // los dos (sin "Hat")
+            var onlyRed = new List<ProductForPurchaseDTO>() { productDTOs[1] };            // solo "Jacket"
+            var onlyByName = new List<ProductForPurchaseDTO>() { productDTOs[0] };          // solo "Shirt" (name contains "irt")
+
+            var tests = new List<object[]>
+            {
+                new object[] { null,   null,  all      }, // sin filtros → ambos con stock>0, ordenados por Colour
+                new object[] { "Red",  null,  onlyRed  }, // filtro por colour → "Jacket"
+                new object[] { null,   "irt", onlyByName },// filtro por name substring → "Shirt"
+            };
+
+            return tests;
+        }
+
+        [Theory]
+        [Trait("LevelTesting", "Unit Testing")]
+        [MemberData(nameof(TestCasesFor_GetProductsForPurchasing_OK))]
+        public async Task GetProductsForPurchasing_filter_test(string? colour, string? name, List<ProductForPurchaseDTO> expected)
+        {
+            var controller = new ProductsController(_context, new Mock<ILogger<ProductsController>>().Object);
+
+            var result = await controller.GetProductsForPurchasing(colour, name);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var actual = Assert.IsType<List<ProductForPurchaseDTO>>(okResult.Value);
+
+            Assert.Equal(expected, actual);
+        }
+    }
+}


### PR DESCRIPTION
Enhanced `ProductForPurchaseDTO` with an `Equals` method for property-based object comparison. Added parameterless and parameterized constructors to `Brand` and `Product` classes for better initialization flexibility.

Introduced `AppForSEII2526SqliteUT` for SQLite-based unit testing, including an in-memory database setup and schema creation with a custom SQL view.

Added `GetProductsForPurchasing_test` to validate the `GetProductsForPurchasing` endpoint with various filter scenarios using parameterized unit tests.