### PR TITLE
PR: Task108 unit tests for get purchaseorder

### DIFF
--- a/src/AppForSEII2526.API/DTOs/ProductDTOs/ProductForPurchaseDTO.cs
+++ b/src/AppForSEII2526.API/DTOs/ProductDTOs/ProductForPurchaseDTO.cs
@@ -36,5 +36,16 @@ namespace AppForSEII2526.API.DTOs.ProductDTOs
 
         // City from related PurchaseOrder (may be null if never purchased)
         public string? City { get; set; }
+
+        public override bool Equals(object? obj)
+        {
+            return obj is ProductForPurchaseDTO dTO &&
+                   ProductId == dTO.ProductId &&
+                   Name == dTO.Name &&
+                   Colour == dTO.Colour &&
+                   Brand == dTO.Brand &&
+                   Stock == dTO.Stock &&
+                   City == dTO.City;
+        }
     }
 }

--- a/src/AppForSEII2526.API/Models/Brand.cs
+++ b/src/AppForSEII2526.API/Models/Brand.cs
@@ -3,6 +3,17 @@
     [Index(nameof(Name), IsUnique = true)]
     public class Brand
     {
+        public Brand()
+        {
+        }
+
+        public Brand(int id, string location, string name)
+        {
+            Id = id;
+            Location = location;
+            Name = name;
+        }
+
         public int Id { get; set; }
 
         public string Location { get; set; }

--- a/src/AppForSEII2526.API/Models/Product.cs
+++ b/src/AppForSEII2526.API/Models/Product.cs
@@ -4,6 +4,21 @@
     [Index(nameof(Name), IsUnique = true)]
     public class Product
     {
+        public Product()
+        {
+        }
+
+        public Product(int productId, string name, string? colour, decimal price, int stock, bool isReturnable, Brand brand)
+        {
+            ProductId = productId;
+            Name = name;
+            Colour = colour;
+            Price = price;
+            Stock = stock;
+            IsReturnable = isReturnable;
+            Brand = brand;
+        }
+
         [Key]
         public int ProductId { get; set; }
 

--- a/test/AppForSEII2526.UT/AppForSEII2526SqliteUT.cs.cs
+++ b/test/AppForSEII2526.UT/AppForSEII2526SqliteUT.cs.cs
@@ -1,0 +1,37 @@
+﻿using System.Data.Common;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+
+namespace AppForSEII2526.UT
+{
+    public class AppForSEII2526SqliteUT
+    {
+        protected readonly DbConnection _connection;
+        protected readonly ApplicationDbContext _context;
+        protected readonly DbContextOptions<ApplicationDbContext> _contextOptions;
+
+        // Si en algún test quieres un contexto "fresco"
+        protected ApplicationDbContext CreateContext() => new(_contextOptions);
+
+        // Importante: cierra la conexión cuando termine el test
+        void Dispose() => _connection.Dispose();
+
+        public AppForSEII2526SqliteUT()
+        {
+            _connection = new SqliteConnection("Filename=:memory:");
+            _connection.Open();
+            _contextOptions = new DbContextOptionsBuilder<ApplicationDbContext>()
+                .UseSqlite(_connection)
+                .Options;
+
+            _context = new ApplicationDbContext(_contextOptions);
+
+            if (_context.Database.EnsureCreated())
+            {
+                using var cmd = _context.Database.GetDbConnection().CreateCommand();
+                cmd.CommandText = @"CREATE VIEW AllProducts AS SELECT Name FROM Products;";
+                cmd.ExecuteNonQuery();
+            }
+        }
+    }
+}

--- a/test/AppForSEII2526.UT/PurchasesController_test/GetProductsForPurchasing_test.cs
+++ b/test/AppForSEII2526.UT/PurchasesController_test/GetProductsForPurchasing_test.cs
@@ -1,0 +1,71 @@
+﻿using AppForSEII2526.UT; // tu base SQLite en memoria (equivalente a AppForMovies4SqliteUT)
+using AppForSEII2526.API.Controllers;
+using AppForSEII2526.API.DTOs.ProductDTOs;
+using AppForSEII2526.API.Models;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace AppForSEII2526.UT.ProductsController_test
+{
+    public class GetProductsForPurchasing_test : AppForSEII2526SqliteUT
+    {
+        public GetProductsForPurchasing_test()
+        {
+            var brands = new List<Brand>() {
+                new Brand { Id = 1, Name = "Zara",   Location = "Madrid"    },
+                new Brand { Id = 2, Name = "Uniqlo", Location = "Barcelona" }
+            };
+
+            var products = new List<Product>(){
+                new Product { ProductId = 1, Name = "Jacket", Colour = "Red",  Price = 20.0m, Stock = 4,  IsReturnable = true,  Brand = brands[0] },
+                new Product { ProductId = 2, Name = "Shirt",  Colour = "Blue", Price = 10.0m, Stock = 10, IsReturnable = false, Brand = brands[1] },
+
+                // this product has stock=0 so it shouldn't be returned when calling GetProductsForPurchasing
+                new Product { ProductId = 3, Name = "Hat",    Colour = "Red",  Price =  5.0m, Stock = 0,  IsReturnable = false, Brand = brands[1] },
+            };
+
+            _context.AddRange(brands);
+            _context.AddRange(products);
+            _context.SaveChanges();
+        }
+
+        public static IEnumerable<object[]> TestCasesFor_GetProductsForPurchasing_OK()
+        {
+            // ¡OJO! El endpoint ordena por Colour (OrderBy Colour).
+            // Colores: "Blue" < "Red" alfabéticamente, por eso "Shirt" va antes que "Jacket".
+            var productDTOs = new List<ProductForPurchaseDTO>() {
+                new ProductForPurchaseDTO(2, "Shirt",  "Blue", "Uniqlo", 10, null),
+                new ProductForPurchaseDTO(1, "Jacket", "Red",  "Zara",    4, null),
+            };
+
+            var all = new List<ProductForPurchaseDTO>() { productDTOs[0], productDTOs[1] }; // los dos (sin "Hat")
+            var onlyRed = new List<ProductForPurchaseDTO>() { productDTOs[1] };            // solo "Jacket"
+            var onlyByName = new List<ProductForPurchaseDTO>() { productDTOs[0] };          // solo "Shirt" (name contains "irt")
+
+            var tests = new List<object[]>
+            {
+                new object[] { null,   null,  all      }, // sin filtros → ambos con stock>0, ordenados por Colour
+                new object[] { "Red",  null,  onlyRed  }, // filtro por colour → "Jacket"
+                new object[] { null,   "irt", onlyByName },// filtro por name substring → "Shirt"
+            };
+
+            return tests;
+        }
+
+        [Theory]
+        [Trait("LevelTesting", "Unit Testing")]
+        [MemberData(nameof(TestCasesFor_GetProductsForPurchasing_OK))]
+        public async Task GetProductsForPurchasing_filter_test(string? colour, string? name, List<ProductForPurchaseDTO> expected)
+        {
+            var controller = new ProductsController(_context, new Mock<ILogger<ProductsController>>().Object);
+
+            var result = await controller.GetProductsForPurchasing(colour, name);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var actual = Assert.IsType<List<ProductForPurchaseDTO>>(okResult.Value);
+
+            Assert.Equal(expected, actual);
+        }
+    }
+}

--- a/test/AppForSEII2526.UT/PurchasesController_test/GetPurchase_test.cs
+++ b/test/AppForSEII2526.UT/PurchasesController_test/GetPurchase_test.cs
@@ -1,0 +1,119 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using AppForSEII2526.API.Controllers;
+using AppForSEII2526.API.DTOs.PurchaseOrderDTOs;
+using AppForSEII2526.API.Models;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace AppForSEII2526.UT.PurchasesController_test
+{
+    public class GetPurchase_test : AppForSEII2526SqliteUT
+    {
+        [Fact]
+        [Trait("Database", "SQLite:Memory")]
+        [Trait("LevelTesting", "Unit Testing")]
+        public async Task GetPurchase_NotFound_test()
+        {
+            var logger = new Mock<ILogger<PurchasesController>>().Object;
+            var ctrl = new PurchasesController(_context, logger);
+
+            var result = await ctrl.GetPurchase(0);
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+
+        [Fact]
+        [Trait("Database", "SQLite:Memory")]
+        [Trait("LevelTesting", "Unit Testing")]
+        public async Task GetPurchase_Found_test()
+        {
+
+            var brand = new Brand { Id = 1, Name = "Zara", Location = "Madrid" };
+            var prod1 = new Product { ProductId = 1, Name = "Jacket", Colour = "Red", Price = 20.0m, Stock = 10, IsReturnable = true, Brand = brand };
+            var prod2 = new Product { ProductId = 2, Name = "Shirt", Colour = "Blue", Price = 10.0m, Stock = 10, IsReturnable = false, Brand = brand };
+            _context.AddRange(brand, prod1, prod2);
+
+            var user = new ApplicationUser
+            {
+                Id = "U1",
+                Name = "Pepe",
+                Surname = "Pérez",
+                Address = "C/ Prueba 1",
+                AccountCreationDate = System.DateTime.UtcNow,
+                UserName = "pepe@test.com",
+                Email = "pepe@test.com"
+            };
+            var pm = new Bizum { User = user, TelephoneNumber = "+34600111222" };
+            _context.AddRange(user, pm);
+            await _context.SaveChangesAsync();
+
+            var order = new PurchaseOrder
+            {
+                City = "Albacete",
+                Street = "Calle Inventada",
+                PostalCode = "02001",
+                NameSurname = "Pepe Pérez",
+                Date = System.DateTime.Now, 
+                State = PurchaseState.Request,
+                Customer = user,
+                PaymentMethodId = pm.Id,
+                TotalPrice = 0m 
+            };
+            _context.PurchaseOrders.Add(order);
+            await _context.SaveChangesAsync();
+
+            var line1 = new PurchaseProduct { PurchaseOrderId = order.Id, ProductId = prod1.ProductId, Price = prod1.Price, Quantity = 2 };
+            var line2 = new PurchaseProduct { PurchaseOrderId = order.Id, ProductId = prod2.ProductId, Price = prod2.Price, Quantity = 1 };
+            _context.PurchaseProducts.AddRange(line1, line2);
+            await _context.SaveChangesAsync();
+
+            order.TotalPrice = line1.Price * line1.Quantity + line2.Price * line2.Quantity; 
+            _context.PurchaseOrders.Update(order);
+            await _context.SaveChangesAsync();
+
+            var expectedId = order.Id;
+            var expectedDate = order.Date;
+            var expectedTotal = order.TotalPrice;
+
+            var logger = new Mock<ILogger<PurchasesController>>().Object;
+            var ctrl = new PurchasesController(_context, logger);
+
+            var result = await ctrl.GetPurchase(expectedId);
+
+            var ok = Assert.IsType<OkObjectResult>(result);
+            var dto = Assert.IsType<PurchaseForDetailDTO>(ok.Value);
+
+            Assert.Equal(expectedId, dto.Id);
+            Assert.Equal(expectedTotal, dto.TotalPrice);
+            Assert.Equal(expectedDate, dto.Date);
+            Assert.Equal("Calle Inventada", dto.Street);
+            Assert.Equal("Albacete", dto.City);
+            Assert.Equal("02001", dto.PostalCode);
+            Assert.Equal("Pepe Pérez", dto.NameSurname);
+
+            Assert.Equal(PurchaseState.Request.ToString(), dto.State);
+            Assert.Equal("Bizum", dto.PaymentMethod);
+
+            Assert.Equal("pepe@test.com", dto.CustomerUserName);
+
+            Assert.Equal(2, dto.Items.Count);
+
+            var item1 = dto.Items.Single(i => i.ProductId == prod1.ProductId);
+            Assert.Equal("Jacket", item1.Name);
+            Assert.Equal("Zara", item1.Brand);
+            Assert.Equal("Red", item1.Colour);
+            Assert.Equal(20.0m, item1.UnitPrice);
+            Assert.Equal(2, item1.Quantity);
+
+            var item2 = dto.Items.Single(i => i.ProductId == prod2.ProductId);
+            Assert.Equal("Shirt", item2.Name);
+            Assert.Equal("Zara", item2.Brand);
+            Assert.Equal("Blue", item2.Colour);
+            Assert.Equal(10.0m, item2.UnitPrice);
+            Assert.Equal(1, item2.Quantity);
+        }
+    }
+}


### PR DESCRIPTION
This pull request adds foundational unit testing infrastructure and initial unit tests for the purchasing features, as well as minor improvements to the domain models and DTOs. The most significant changes include the introduction of a reusable SQLite in-memory test base, comprehensive tests for purchase retrieval and product filtering, and enhancements to model constructors and equality checks.

**Testing Infrastructure:**

* Added a reusable base class `AppForSEII2526SqliteUT` for unit tests, which sets up an in-memory SQLite database and initializes the schema, making it easier to write isolated and repeatable tests.

**Unit Tests for Controllers:**

* Implemented `GetPurchase_test` for `PurchasesController`, covering both "not found" and "found" scenarios, including detailed assertions on returned DTOs and nested data.
* Added `GetProductsForPurchasing_test` for `ProductsController`, verifying product filtering by colour and name, and ensuring only products with stock are returned, sorted as expected.

**Model and DTO Improvements:**

* Added parameterized constructors to `Brand` and `Product` models to facilitate easier object creation in tests and other contexts. [[1]](diffhunk://#diff-2006cf6e6e1cb74ac6079433bdafa5f091114bfa94c41dd18de42e3a2ae782baR6-R16) [[2]](diffhunk://#diff-35a9ff2a2e55fa70aa7cf69f957e2e7949c6bd75be98e9016704cbb84016c9c5R7-R21)
* Implemented an override of `Equals` in `ProductForPurchaseDTO` to support value-based equality, simplifying assertions in tests.